### PR TITLE
provide get/post/put helpers to abstract json level of api

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ echo json_decode($response->getBody(), true)['version'];
 Get information about me:
 
 ```php
-$response = $client->get('/me');
+$response = $client->get('me');
 echo json_decode($response->getBody(), true)['firstname'];
 //John
 ```
@@ -63,7 +63,7 @@ echo json_decode($response->getBody(), true)['firstname'];
 Update my firstname:
 
 ```php
-$client->put('/me', [
+$client->put('me', [
     'firstname' => 'John'
 ]);
 ```
@@ -71,7 +71,7 @@ $client->put('/me', [
 Create a project:
 
 ```php
-$client->post('/projects', [
+$client->post('projects', [
 	'title' => '',
 	'description' => '',
 	'organization' => '',

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,13 @@ use GuzzleHttp\Client as GuzzleClient;
 class Client extends GuzzleClient
 {
     /**
+     * The API format to send/recieve : json, xml...
+     *
+     * @var string
+     */
+    protected $format = 'json';
+
+    /**
      * Constructor
      * {@inheritdoc}
      */
@@ -21,6 +28,9 @@ class Client extends GuzzleClient
             $config['headers'] = [
                 'Authorization' => 'Bearer '.$config['access_token'],
             ];
+        }
+        if (!empty($config['format']) && in_array($config['format'], ['json'])) {
+            $this->format = $config['format'];
         }
         parent::__construct($config);
     }
@@ -39,14 +49,14 @@ class Client extends GuzzleClient
 
     public function put($uri, $body = [], $options = [])
     {
-        $requestBody = array_merge($options, ['json' => $body]);
+        $requestBody = array_merge($options, [$this->format => $body]);
 
         return parent::request('PUT', $uri, $requestBody);
     }
 
     public function post($uri, $body = [], $options = [])
     {
-        $requestBody = array_merge($options, ['json' => $body]);
+        $requestBody = array_merge($options, [$this->format => $body]);
 
         return parent::request('POST', $uri, $requestBody);
     }
@@ -54,7 +64,12 @@ class Client extends GuzzleClient
     public function get($uri = '')
     {
         $response = parent::get($uri);
-        $parsedResponse = json_decode($response->getBody(), true);
+        switch ($this->format) {
+            case 'json':
+            default:
+                $parsedResponse = json_decode($response->getBody(), true);
+                break;
+        }
 
         return $parsedResponse;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -61,7 +61,7 @@ class Client extends GuzzleClient
         return parent::request('POST', $uri, $requestBody);
     }
 
-    public function get($uri = '')
+    public function get($uri)
     {
         $response = parent::get($uri);
         switch ($this->format) {

--- a/src/Client.php
+++ b/src/Client.php
@@ -43,7 +43,7 @@ class Client extends GuzzleClient
     protected function getDefaultClientConfig()
     {
         return [
-            'base_uri' => 'https://api.creads-partners.com/v1',
+            'base_uri' => 'https://api.creads-partners.com/v1/',
         ];
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,21 +19,44 @@ class Client extends GuzzleClient
 
         if (!empty($config['access_token'])) {
             $config['headers'] = [
-                'Authorization' => 'Bearer ' . $config['access_token']
+                'Authorization' => 'Bearer '.$config['access_token'],
             ];
         }
         parent::__construct($config);
     }
 
     /**
-     * Get default configuration to apply the client
+     * Get default configuration to apply the client.
+     *
      * @return array
      */
     protected function getDefaultClientConfig()
     {
         return [
-            'base_uri' => 'https://api.creads-partners.com/v1'
+            'base_uri' => 'https://api.creads-partners.com/v1',
         ];
+    }
+
+    public function put($uri = '', $body = [])
+    {
+        return parent::request('PUT', $uri, [
+            'json' => $body,
+        ]);
+    }
+
+    public function post($uri = '', $body = [])
+    {
+        return parent::request('POST', $uri, [
+            'json' => $body,
+        ]);
+    }
+
+    public function get($uri = '')
+    {
+        $response = parent::get($uri);
+        $parsedResponse = json_decode($response->getBody(), true);
+
+        return $parsedResponse;
     }
 
     // /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -37,18 +37,18 @@ class Client extends GuzzleClient
         ];
     }
 
-    public function put($uri = '', $body = [])
+    public function put($uri, $body = [], $options = [])
     {
-        return parent::request('PUT', $uri, [
-            'json' => $body,
-        ]);
+        $requestBody = array_merge($options, ['json' => $body]);
+
+        return parent::request('PUT', $uri, $requestBody);
     }
 
-    public function post($uri = '', $body = [])
+    public function post($uri, $body = [], $options = [])
     {
-        return parent::request('POST', $uri, [
-            'json' => $body,
-        ]);
+        $requestBody = array_merge($options, ['json' => $body]);
+
+        return parent::request('POST', $uri, $requestBody);
     }
 
     public function get($uri = '')


### PR DESCRIPTION
@pitpit This allows us to do `$partners->get('/resource');` without having to `->getBody()` and `json_decode` as Partners API only recieves/sends json bodies
