### PR TITLE
use scope variable for file and not hardcoded value

### DIFF
--- a/src/OAuthAccessToken.php
+++ b/src/OAuthAccessToken.php
@@ -65,7 +65,7 @@ class OAuthAccessToken implements AuthenticationInterface
                 ],
                 [
                     'name' => 'scope',
-                    'contents' => 'base',
+                    'contents' => $scope,
                 ],
             ];
             if (isset($this->params['grant_type']) && $this->params['grant_type'] === 'password') {


### PR DESCRIPTION
It is quite important as we sometime need to get "file" specific token with the file scope
