### PR TITLE
[OUT OF SCOPE] Add options to command signed-auth-url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 vendor/
 composer.lock

--- a/src/Console/Command/SignedAuthUrlCommand.php
+++ b/src/Console/Command/SignedAuthUrlCommand.php
@@ -70,23 +70,23 @@ class SignedAuthUrlCommand extends Command
         $configuration = $this->getHelperSet()->get('configuration');
 
         $protocol = $input->getOption('protocol');
-        $api_base_uri = $input->getOption('api-base-uri');
-        $client_id = $input->getOption('client-id');
-        $client_secret = $input->getOption('client-secret');
+        $apiBaseUri = $input->getOption('api-base-uri');
+        $clientId = $input->getOption('client-id');
+        $clientSecret = $input->getOption('client-secret');
 
-        if (($client_id && !$client_secret) || (!$client_id && $client_secret)) {
+        if (($clientId && !$clientSecret) || (!$clientId && $clientSecret)) {
             throw new \RuntimeException('Options --client-id & --client-secret have to be set together');
         } elseif (!in_array($protocol, SignedAuthenticationUrlFactory::getAvailableProtocols())) {
             throw new \RuntimeException('Invalid value for protocol');
         }
 
-        if ($api_base_uri) {
-            $configuration['api_base_uri'] = $api_base_uri;
+        if ($apiBaseUri) {
+            $configuration['api_base_uri'] = $apiBaseUri;
         }
 
-        if ($client_id && $client_secret) {
-            $configuration['client_id'] = $client_id;
-            $configuration['client_secret'] = $client_secret;
+        if ($clientId && $clientSecret) {
+            $configuration['client_id'] = $clientId;
+            $configuration['client_secret'] = $clientSecret;
         }
 
         $signedUrl = SignedAuthenticationUrlFactory::create(

--- a/src/Console/Command/SignedAuthUrlCommand.php
+++ b/src/Console/Command/SignedAuthUrlCommand.php
@@ -45,7 +45,7 @@ class SignedAuthUrlCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Set api base URI than default'
             )->addOption(
-                'client_id',
+                'client-id',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Set client ID than default'
@@ -70,9 +70,23 @@ class SignedAuthUrlCommand extends Command
         $configuration = $this->getHelperSet()->get('configuration');
 
         $protocol = $input->getOption('protocol');
+        $api_base_uri = $input->getOption('api-base-uri');
+        $client_id = $input->getOption('client-id');
+        $client_secret = $input->getOption('client-secret');
 
-        if (!in_array($protocol, SignedAuthenticationUrlFactory::getAvailableProtocols())) {
+        if (($client_id && !$client_secret) || (!$client_id && $client_secret)) {
+            throw new \RuntimeException('Options --client-id & --client-secret have to be set together');
+        } elseif (!in_array($protocol, SignedAuthenticationUrlFactory::getAvailableProtocols())) {
             throw new \RuntimeException('Invalid value for protocol');
+        }
+
+        if ($api_base_uri) {
+            $configuration['api_base_uri'] = $api_base_uri;
+        }
+
+        if ($client_id && $client_secret) {
+            $configuration['client_id'] = $client_id;
+            $configuration['client_secret'] = $client_secret;
         }
 
         $signedUrl = SignedAuthenticationUrlFactory::create(

--- a/src/Console/Command/SignedAuthUrlCommand.php
+++ b/src/Console/Command/SignedAuthUrlCommand.php
@@ -2,7 +2,6 @@
 
 namespace Creads\Partners\Console\Command;
 
-use Creads\Partners\ClientFactory;
 use Creads\Partners\SignedAuthenticationUrlFactory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -40,7 +39,22 @@ class SignedAuthUrlCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Set protocol to another version than default',
                 SignedAuthenticationUrlFactory::RFC1_SIGNATURE_PROTOCOL
-            );
+            )->addOption(
+                'api-base-uri',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Set api base URI than default'
+            )->addOption(
+                'client_id',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Set client ID than default'
+            )->addOption(
+                'client-secret',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Set client secret than default'
+            )
         ;
     }
 
@@ -75,5 +89,4 @@ class SignedAuthUrlCommand extends Command
 
         $output->writeln(sprintf('<comment>%s</comment>', $signedUrl));
     }
-
 }


### PR DESCRIPTION
**This PR is not attached to a Milestone - this is an optional feature "Dev only"**

I added three new options to overwrite the generated link.
Like this, we can generate links for different client and different environment of our production pipeline, without editing `~/.partners.json` used by the vendor.

- `--client-id <param>`, works only if `--client-secret` is also set
- `--client-secret <param>`, works only if `--client-id` is also set
- `--api-base-uri <http://param.com/>`, could be used alone

```
$> bin/partners signed-auth-url Creads antoine@benevaut.fr --client-id test --client-secret test --api-base-uri http://test/ --protocol 0

Output :
http://test/signed-auth/Q3JlYWRz/YW50b2luZUBiZW5ldmF1dC5mcg==?expires=20181130T095400Z&signature=1d9cf533e7be7c164830ac0bf2e0174dcf99c7e51239425bc58da42d7b899f96&accessKeyId=test
```