### PR TITLE
✨ Rendre obligatoire les tests Travis PHP7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: php
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
+  - 7.1
+  - 7.2
+  - nightly
 
 matrix:
   allow_failures:
-    - php: 7.0
+    - php: 7.1
 
 install:
   - composer install -n --no-progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 
 php:
+  - 5.5
+  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -8,7 +10,10 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7.1
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: nightly
 
 install:
   - composer install -n --no-progress


### PR DESCRIPTION
FIX :
https://creads.atlassian.net/browse/CREADS-614

**Update du travis.yml**

+ Fin des tests PHP 5.5 & 5.6
+ Ajout des versions 7.1 & 7.2 + Nightly
+ Fail interdit pour la version 7.0
+ Fail autorisé pour la version 7.1